### PR TITLE
fix kivy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 playwright==1.40.0
-kivy==2.2.1
+kivy>=2.2.1


### PR DESCRIPTION
The kivy 2.2.1 package installation occurs an error :
*ERROR: Could not find a version that satisfies the requirement kivy_deps.sdl2_dev~=0.6.0 (from versions: 0.7.0)*  
*ERROR: No matching distribution found for kivy_deps.sdl2_dev~=0.6.0*

Install a higher version seems to work.